### PR TITLE
Add SECTION_TITLES alias

### DIFF
--- a/src/section_titles.py
+++ b/src/section_titles.py
@@ -9,3 +9,7 @@ class SectionTitles(Enum):
     BANKING_IMPACT = "Banking Impact"
     IMPLEMENTATION_GUIDANCE = "Implementation Guidance"
     # Add more as needed
+
+
+# Alias used across the codebase for convenience
+SECTION_TITLES = SectionTitles


### PR DESCRIPTION
## Summary
- expose a `SECTION_TITLES` alias in `section_titles.py`

## Testing
- `python -m py_compile src/section_titles.py`
- `PYTHONPATH=src python - <<'EOF'
import types, sys
mistletoe = types.ModuleType('mistletoe')
class Document: pass
mistletoe.Document = Document
block_token = types.ModuleType('block_token')
class BlockToken: pass
class Heading: pass
class BlockCode: pass
block_token.BlockToken = BlockToken
block_token.Heading = Heading
block_token.BlockCode = BlockCode
mistletoe.block_token = block_token
markdown_renderer = types.ModuleType('markdown_renderer')
class MarkdownRenderer: pass
markdown_renderer.MarkdownRenderer = MarkdownRenderer
mistletoe.markdown_renderer = markdown_renderer
sys.modules['mistletoe'] = mistletoe
sys.modules['mistletoe.block_token'] = block_token
sys.modules['mistletoe.markdown_renderer'] = markdown_renderer
openai = types.ModuleType('openai')
class OpenAI: pass
openai.OpenAI = OpenAI
sys.modules['openai'] = openai
import section_titles
import character_role_suggester
import panel_section_manager
import enhanced_batch_processor
import role_validator_tool
print('import success')
EOF