### PR TITLE
Fix docstring in base_batch_processor

### DIFF
--- a/src/base_batch_processor.py
+++ b/src/base_batch_processor.py
@@ -60,7 +60,7 @@ class BaseBatchProcessor:
             panel: The panel to process
 
         Returns:
-            Number of enhancements applied
+            Mapping of section titles to enhancement suggestions
         """
         section_map = doc.extract_named_sections_from_panel(panel.panel_number_in_doc)
         if not section_map:


### PR DESCRIPTION
## Summary
- clarify the return value of `process_panel`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*